### PR TITLE
Reorder exit condition from executor

### DIFF
--- a/kernel/waker_executor/src/lib.rs
+++ b/kernel/waker_executor/src/lib.rs
@@ -42,10 +42,10 @@ impl WakerExecutor {
 
     pub fn run(&mut self) -> Result<(), ()> {
         loop {
+            self.run_ready_tasks();
             if self.tasks.is_empty() {
                 return Ok(());
             }
-            self.run_ready_tasks();
             self.sleep_if_idle();
         }
     }


### PR DESCRIPTION
This should prevent the executor from becoming stuck sleeping in the case where all tasks were finished in the last call to run_ready_tasks()